### PR TITLE
Update dependency gem for ruby 2.4 support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in xx.gemspec
 gemspec
+
+gem 'net-dns3', :git => 'https://github.com/kouzoh/net-dns3.git'

--- a/roadworker.gemspec
+++ b/roadworker.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk", "~> 2.2"
   spec.add_dependency "term-ansicolor"
-  spec.add_dependency "net-dns2", "~> 0.8.6"
+  spec.add_dependency "net-dns3", "~> 0.1.0"
   spec.add_dependency "uuid"
   spec.add_dependency "systemu"
   spec.add_dependency "diffy"


### PR DESCRIPTION
- net-dns2
  - This Gem has no repository already.
  - すでにこのGemはGithubから消えているので、暫定対応

- Workaround
  - https://github.com/kouzoh/net-dns3